### PR TITLE
Allow Overriding HttpClient

### DIFF
--- a/lib/net/authorize/api/controller/base/ApiOperationBase.php
+++ b/lib/net/authorize/api/controller/base/ApiOperationBase.php
@@ -86,6 +86,12 @@ abstract class ApiOperationBase implements IApiOperation
         $this->serializer = $serializerBuilder->build();*/
     }
 
+    public function setHttpClient($httpClient)
+    {
+        $this->httpClient = $httpClient;
+        return $this;
+    }
+
     /**
      * Retrieves response
      * @return \net\authorize\api\contract\v1\AnetApiResponseType


### PR DESCRIPTION
This adds a method to ApiOperationsBase to override the HttpClient. ApiOperationsBase is extended by Controllers, so this will allow using the SDK during tests, but mocking the connection.